### PR TITLE
fix missing saved_stack in order to be able to compile again

### DIFF
--- a/src/bjam/function.c
+++ b/src/bjam/function.c
@@ -3783,6 +3783,7 @@ LIST * function_run( FUNCTION * function_, FRAME * frame, STACK * s )
     instruction * code;
     LIST * l;
     LIST * result = L0;
+    void * saved_stack = s->data;
 
     PROFILE_ENTER_LOCAL(function_run);
 


### PR DESCRIPTION
Fixes [Issue #16](https://github.com/stefanseefeld/faber/issues/16)