### PR TITLE
Use asyncio.new_event_loop().

### DIFF
--- a/.github/workflows/test-osx.yml
+++ b/.github/workflows/test-osx.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', 'pypy-3.8', 'pypy-3.9']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14', 'pypy-3.8', 'pypy-3.9']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v4

--- a/src/faber/artefacts/install.py
+++ b/src/faber/artefacts/install.py
@@ -11,11 +11,12 @@ from ..tools.installer import installer, prefix, stage  # noqa F401
 from ..rule import rule, alias
 from .. import platform
 from os.path import normpath, join, splitdrive
+import os
 
-default_prefix = prefix('/usr/local')
 if platform.os == 'Windows':
-    default_prefix = prefix(r'C:/Program Files')
-
+    default_prefix = prefix(os.environ['ProgramFiles'])
+else:
+    default_prefix = prefix('/usr/local')
 
 class _installed(artefact):
     """An installed artefact has a filename outside the build directory."""

--- a/src/faber/cache.py
+++ b/src/faber/cache.py
@@ -31,6 +31,7 @@ class filecache(object):
 
     def __del__(self):
         self.conn.commit()
+        self.conn.close()
 
     def append(self, filename):
         with self.conn:

--- a/src/faber/scheduler/asyncio.py
+++ b/src/faber/scheduler/asyncio.py
@@ -19,6 +19,13 @@ __all__ = ['init', 'reset', 'clean', 'finish',
            'variables', 'define_artefact', 'add_dependency', 'define_recipe',
            'run', 'update', 'print_dependency_graph', 'DependencyError']
 
+if sys.platform == 'win32':
+    loop = asyncio.ProactorEventLoop()
+    asyncio.set_event_loop(loop)
+else:
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
 
 artefacts = {}  # map frontends to backends
 
@@ -75,15 +82,8 @@ def run(command):
 
 
 def update(aa):
-    if sys.version_info >= (3, 10):
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-    elif sys.platform == 'win32':
-        loop = asyncio.ProactorEventLoop()
-        asyncio.set_event_loop(loop)
-    else:
-        loop = asyncio.get_event_loop()
     try:
+        loop = asyncio.get_event_loop()
         aa = [artefacts[a] for a in aslist(aa)]
         loop.run_until_complete(asyncio.gather(*[a.process() for a in aa]))
         return all([a.status for a in aa])

--- a/src/faber/scheduler/asyncio.py
+++ b/src/faber/scheduler/asyncio.py
@@ -19,10 +19,6 @@ __all__ = ['init', 'reset', 'clean', 'finish',
            'variables', 'define_artefact', 'add_dependency', 'define_recipe',
            'run', 'update', 'print_dependency_graph', 'DependencyError']
 
-if sys.platform == 'win32':
-    loop = asyncio.ProactorEventLoop()
-    asyncio.set_event_loop(loop)
-
 
 artefacts = {}  # map frontends to backends
 
@@ -79,8 +75,15 @@ def run(command):
 
 
 def update(aa):
-    try:
+    if sys.version_info >= (3, 10):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    elif sys.platform == 'win32':
+        loop = asyncio.ProactorEventLoop()
+        asyncio.set_event_loop(loop)
+    else:
         loop = asyncio.get_event_loop()
+    try:
         aa = [artefacts[a] for a in aslist(aa)]
         loop.run_until_complete(asyncio.gather(*[a.process() for a in aa]))
         return all([a.status for a in aa])


### PR DESCRIPTION
This replaces the use of the deprecated get_event_loop() function.  In Python 3.14, get_event_loop() raises RuntimeError if there is no current event loop.