### PR TITLE
Preserve original LD_LIBRARY_PATH components.

### DIFF
--- a/src/faber/tools/python.py
+++ b/src/faber/tools/python.py
@@ -31,7 +31,9 @@ class run(action):
 set PYTHONPATH=$(pythonpath)
 python $(>)"""
     else:
-        command = 'LD_LIBRARY_PATH=$(runpath) PYTHONPATH=$(pythonpath) python $(>)'
+        command = ('LD_LIBRARY_PATH=$(runpath):$LD_LIBRARY_PATH '
+                   'PYTHONPATH=$(pythonpath) '
+                   'python $(>)')
 
 
 class python(tool):


### PR DESCRIPTION
For the "python" tool, preserve the original components of LD_LIBRARY_PATH from the environment.

This caused me quite a lot of debugging time.  If you install Python into a non-standard location and built it using `--enable-shared`, the Python executable will not be able to find Python shared libraries.  One possible fix would be to set the rpath in the ELF files, like this:

`patchelf --set-rpath "\$ORIGIN/../lib" /path-to-python/bin/python3.xy`

Another idea that should work is to create a wrapper script, that sets LD_LIBRARY_PATH, e.g.
```
#!/bin/sh
prefix=/path-to-python
export LD_LIBRARY_PATH=$prefix/lib
exec $prefix/bin/python3
```
This fails with `faber` since it overrides the `LD_LIBRARY_PATH` environment variable.  I think preserving the original components of it, like this patch does, is better.  There should be little risk in doing so.